### PR TITLE
Ensuring /test /test/ and /test/index.html all work

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -1,5 +1,5 @@
 requirejs.config({
-  baseUrl: 'js',
+  baseUrl: '/js',
 
   paths: {
   },

--- a/server.js
+++ b/server.js
@@ -8,7 +8,6 @@ app = connect()
   .use('/js/lib/', connect.static('node_modules/requirejs/'))
   .use('/node_modules', connect.static('node_modules'))
   .use('/test', connect.static('test/'))
-  .use('/test', connect.static('app'))
   ;
 
 http.createServer(app).listen(8080, function() {

--- a/test/index.html
+++ b/test/index.html
@@ -14,8 +14,8 @@
   <script src="/node_modules/mocha/mocha.js"></script>
   <script src="/js/lib/require.js"></script>
   <script src="/js/main.js"></script>
-  <script src="setup.js"></script>
-  <script src="app.test.js"></script>
+  <script src="/test/setup.js"></script>
+  <script src="/test/app.test.js"></script>
   <script>require(['app'], function() { mocha.run(); });</script>
 </body>
 </html>


### PR DESCRIPTION
This commit ensures that /test /test/ and /test/index.html all work (/test doesn't now).

Also, as a few commenters noted, `.use('/test', connect.static('test'))` isn't a part of the blog.

Nice article!
